### PR TITLE
Fixing CI pipeline by removing warnings

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -48,7 +48,6 @@ ghc-options:
 - -Wredundant-constraints
 - -fno-warn-name-shadowing
 - -fno-warn-incomplete-uni-patterns
-- -fno-warn-type-defaults
 
 library:
   source-dirs: src

--- a/package.yaml
+++ b/package.yaml
@@ -49,8 +49,6 @@ ghc-options:
 - -fno-warn-name-shadowing
 - -fno-warn-incomplete-uni-patterns
 - -fno-warn-type-defaults
-- -fno-warn-overlapping-patterns
-- -fno-warn-x-partial
 
 library:
   source-dirs: src

--- a/package.yaml
+++ b/package.yaml
@@ -46,6 +46,7 @@ ghc-options:
 - -Wmissing-home-modules
 - -Wpartial-fields
 - -Wredundant-constraints
+- -fno-warn-name-shadowing
 
 library:
   source-dirs: src

--- a/package.yaml
+++ b/package.yaml
@@ -47,6 +47,10 @@ ghc-options:
 - -Wpartial-fields
 - -Wredundant-constraints
 - -fno-warn-name-shadowing
+- -fno-warn-incomplete-uni-patterns
+- -fno-warn-type-defaults
+- -fno-warn-overlapping-patterns
+- -fno-warn-x-partial
 
 library:
   source-dirs: src

--- a/src/Zap/AST.hs
+++ b/src/Zap/AST.hs
@@ -253,7 +253,7 @@ registerSpecializedStruct specializationName baseDef paramTypes st =
 
 -- Helper to instantiate a function definition with concrete types
 specializeFunctionDef :: FunctionDef -> [Type] -> SymbolTable -> Either String FunctionDef
-specializeFunctionDef def typeArgs st
+specializeFunctionDef def typeArgs _
     | length (funcTypeParams def) /= length typeArgs =
         Left $ "Wrong number of type arguments for " ++ funcName def
     | otherwise = do

--- a/src/Zap/Analysis/Semantic.hs
+++ b/src/Zap/Analysis/Semantic.hs
@@ -307,7 +307,8 @@ checkExpr = \case
         (vars, _, _, _, _) <- get
         unless (M.member name vars) $
             throwError $ UndefinedVariable name
-
+    
+    _ -> return () -- TODO: Checks for structLit, ArrayLit & Index are yet to be added
   where
     getBaseType :: Expr -> VarEnv -> SymbolTable -> SemCheck Type
     getBaseType expr vars symTable = do

--- a/src/Zap/Compiler.hs
+++ b/src/Zap/Compiler.hs
@@ -83,7 +83,7 @@ compile' opts source = do
   -- Create Program with symbol table
   astResult <- if targetStage opts >= Parsing
     then case (parsedAST parseResult, symbolTable parseResult) of
-      (Just topLevels, Just symTable) -> do
+      (Just topLevels, Just _) -> do
         let prog = Program topLevels
         return $ parseResult { program = Just prog }
       _ -> return parseResult

--- a/src/Zap/IR.hs
+++ b/src/Zap/IR.hs
@@ -935,7 +935,7 @@ convertToLiteral expr = case expr of
             Just Int32 -> Right $ IRInt32Lit (read val)
             Just Int64 -> Right $ IRInt64Lit (read val)
             _ ->
-              if read val > (2^31 - 1)
+              if (read val :: Integer) > (2^(31 :: Int) - 1)
                  then Right $ IRInt64Lit (read val)
                  else Right $ IRInt32Lit (read val)
         FloatLit val mtype ->
@@ -980,7 +980,7 @@ convertToIRExprWithSymbols _ (Lit lit) = case lit of
         Just Int32 -> Right $ IRLit $ IRInt32Lit (read val)
         Just Int64 -> Right $ IRLit $ IRInt64Lit (read val)
         _ ->
-          if read val > (2^31 - 1)
+          if (read val :: Integer) > (2^(31 :: Int) - 1)
              then Right $ IRLit $ IRInt64Lit (read val)
              else Right $ IRLit $ IRInt32Lit (read val)
     FloatLit val mtype ->

--- a/src/Zap/IR.hs
+++ b/src/Zap/IR.hs
@@ -258,7 +258,7 @@ generateSpecializedVersions st (DFunc name typeParams params retType body) = do
              [Param n (substituteTypeParamWithSymbols tp concreteType t st) |
               Param n t <- params,
               tp <- typeParams]
-             (substituteTypeParamWithSymbols (head typeParams) concreteType retType st)
+             (substituteTypeParamWithSymbols (typeParams !! 0) concreteType retType st)
              body
       ) specialized
   where
@@ -704,14 +704,13 @@ convertTop symTable (TLExpr (If cond thenExpr elseExpr)) ctx = do
          ++ [ (IRLabel endLabel, meta) ]
 
     return result
-
-convertTop _ (TLExpr (If _ _ (Lit (BooleanLit False)))) _ = do
-    -- Omitted for brevity (unchanged)
-    -- ...
-    -- ...
-    -- This remains the same as your existing code
-    Left $ IRUnsupportedExpr "If cond then expr else false unimplemented in snippet"
-
+-- This case is unreachable
+-- convertTop _ (TLExpr (If _ _ (Lit (BooleanLit False)))) _ = do
+--     -- Omitted for brevity (unchanged)
+--     -- ...
+--     -- ...
+--     -- This remains the same as your existing code
+--     Left $ IRUnsupportedExpr "If cond then expr else false unimplemented in snippet"
 convertTop symTable (TLExpr (While cond body)) prevCtx = do
     -- Unchanged from your code
     let nextNum = case prevCtx of
@@ -1145,8 +1144,8 @@ convertToIRExprWithSymbols _ e = do
 --------------------------------------------------------------------------------
 
 isFnameStructConstructor :: String -> Bool
-isFnameStructConstructor nm =
-    not (null nm) && C.isUpper (head nm)
+isFnameStructConstructor (c:_) = C.isUpper c
+isFnameStructConstructor [] = False
 
 opToString :: Op -> String
 opToString Add = "Add"

--- a/src/Zap/Parser/Core.hs
+++ b/src/Zap/Parser/Core.hs
@@ -78,7 +78,7 @@ checkBlockIndent :: BlockType -> Int -> Parser ()
 checkBlockIndent bt bi = do
     st <- get
     case stateTokens st of
-        (tok:rest) -> do
+        (tok:_) -> do
             let tokCol = locCol tok
             traceM $ "=== checkBlockIndent ==="
             traceM $ "Block type: " ++ show bt

--- a/src/Zap/Parser/Core.hs
+++ b/src/Zap/Parser/Core.hs
@@ -100,6 +100,7 @@ checkBlockIndent bt bi = do
                     FunctionBlock -> do
                         when (tokCol > 1 && tokCol < bi) $
                             throwError $ IndentationError $ IndentationErrorDetails bi tokCol GreaterEq
+                    _ -> return () --TODO: Need a check on TypeBlock.
         [] -> return ()
 
 -- | Get the next token if it matches
@@ -137,3 +138,4 @@ validateIndent ctx col = do
         throwError $ IndentationError $ IndentationErrorDetails (baseIndent ctx) col Greater
 
     TopLevel -> return () -- No indentation rules at top level
+    _ -> return () --TODO: Need validation on TypeBlock.

--- a/src/Zap/Parser/Expr.hs
+++ b/src/Zap/Parser/Expr.hs
@@ -21,6 +21,8 @@ module Zap.Parser.Expr
   , isStringLit
   , isValidName
   , isOperator
+  , createNumericLiteral 
+  , parseParamType 
   ) where
 
 import Control.Monad (when)
@@ -430,7 +432,7 @@ parseFieldOrCallChain expr = do
                       case M.lookup name (structNames (stateSymTable st)) of
                           Just sid -> case lookupStruct sid (stateSymTable st) of
                               Just baseDef -> do
-                                  let (specializedId, newSymTable) =
+                                  let (_, newSymTable) =
                                         registerSpecializedStruct specializedName baseDef paramTypes (stateSymTable st)
                                   modify $ \s -> s { stateSymTable = newSymTable }
                               Nothing -> return ()
@@ -821,14 +823,13 @@ parseSingleBindingLine = do
             -- Register annotated type if present
             case annotatedType of
                 Just typ -> do
-                    st <- get
                     modify $ \s -> s { stateSymTable =
                         registerVarType varName typ (stateSymTable s) }
                 Nothing -> return ()
 
             -- Register type if we can determine it
             case value of
-                Call structName args -> do  -- Struct instantiation
+                Call structName _ -> do  -- Struct instantiation
                     st <- get
                     case M.lookup structName (structNames $ stateSymTable st) of
                         Just sid ->
@@ -1426,7 +1427,7 @@ parseVarDecl = do
             -- Register variable type if annotation was present
             case annotatedType of
                 Just typ -> do
-                    st <- get
+                    _ <- get
                     modify $ \s -> s { stateSymTable =
                         registerVarType name typ (stateSymTable s) }
                 Nothing -> return ()

--- a/src/Zap/Parser/Expr.hs
+++ b/src/Zap/Parser/Expr.hs
@@ -651,7 +651,8 @@ parseCallArgs = do
                 parseMoreArgs [firstArg]
         _ -> return [] --TODO: State shouldn't be empty
   where
-    isConstructorName name = not (null name) && isUpper (head name)
+    isConstructorName (n:_) = isUpper n
+    isConstructorName [] = False
     parseMoreArgs acc = do
         st <- get
         case stateTokens st of
@@ -1402,8 +1403,7 @@ parseTypeToken tok = case locToken tok of
     TWord "f32" -> return $ TypeNum Float32
     TWord "f64" -> return $ TypeNum Float64
     -- NEW: Handle type parameters as valid types
-    TWord name | length name == 1 && isUpper (head name) ->
-        return $ TypeParam name
+    TWord [c] | isUpper c -> return $ TypeParam [c]
     _ -> throwError $ UnexpectedToken tok "valid type"
 
 parseVarDecl :: Parser Expr

--- a/src/Zap/Parser/Program.hs
+++ b/src/Zap/Parser/Program.hs
@@ -335,7 +335,7 @@ parseType = do
                 (next:_) | locToken next == TLeftBracket -> do
                     traceM $ "Parsing generic type reference: " ++ typeName
                     -- Parse the type parameter
-                    params <- parseTypeParams
+                    _ <- parseTypeParams
                     -- Look up base struct in symbol table
                     case M.lookup typeName (structNames $ stateSymTable st) of
                         Just sid -> do

--- a/src/Zap/Parser/Program.hs
+++ b/src/Zap/Parser/Program.hs
@@ -348,12 +348,12 @@ parseType = do
 
                 -- Original cases for basic types and type parameters
                 _ -> case typeName of
-                    "i32" -> return $ TypeNum Int32
-                    "i64" -> return $ TypeNum Int64
-                    "f32" -> return $ TypeNum Float32
-                    "f64" -> return $ TypeNum Float64
+                    -- "i32" -> return $ TypeNum Int32
+                    -- "i64" -> return $ TypeNum Int64
+                    -- "f32" -> return $ TypeNum Float32
+                    -- "f64" -> return $ TypeNum Float64
                     -- Single uppercase letter is a type parameter
-                    _ | length typeName == 1 && isUpper (head typeName) ->
+                    _ | length typeName == 1 && isUpper (typeName !! 0) ->
                         return $ TypeParam typeName
                     _ -> throwError $ UnexpectedToken tok "type name"
         _ -> throwError $ UnexpectedToken tok "type name"

--- a/test/Zap/Analysis/SemanticSpec.hs
+++ b/test/Zap/Analysis/SemanticSpec.hs
@@ -3,8 +3,6 @@ module Zap.Analysis.SemanticSpec (spec) where
 
 import Test.Hspec
 import qualified Data.Text as T
-import qualified Data.Map.Strict as M
-import Debug.Trace
 
 import Zap.AST
 import Zap.Analysis.Semantic

--- a/test/Zap/Codegen/CSpec.hs
+++ b/test/Zap/Codegen/CSpec.hs
@@ -18,7 +18,7 @@ spec = do
           let program = IRProgram
                 [ ( IRFuncDecl "main" [] IRTypeVoid
                     (IRBlock "entry"
-                      [ (IRVarDecl "x" IRTypeInt32 (IRLit (IRInt32Lit 5)), testMeta)
+                      [ (IRVarDecl (IRVarDeclData "x" IRTypeInt32 (IRLit (IRInt32Lit 5))), testMeta)
                       , (IRAssign "x" (IRLit (IRInt32Lit 3)), testMeta)
                       ])
                   , testMeta)
@@ -47,12 +47,12 @@ spec = do
           let symTable = snd $ registerStruct "Point"
                                 [("x", TypeNum Int32), ("y", TypeNum Int32)]
                                 emptySymbolTable
-          let pointDecl = IRVarDecl "p"
+          let pointDecl = IRVarDecl (IRVarDeclData "p"
                 (IRTypeStruct "Point" (StructId 0))
                 (IRCall "struct_lit"
                   [IRLit (IRStringLit "Point"),
                    IRLit (IRInt32Lit 10),
-                   IRLit (IRInt32Lit 20)])
+                   IRLit (IRInt32Lit 20)]))
           let testMetaWithStruct = testMeta { metaSymTable = Just symTable }
           let program = IRProgram
                 [(IRFuncDecl "main" [] IRTypeVoid
@@ -69,12 +69,12 @@ spec = do
           let symTable = snd $ registerStruct "Point"
                                 [("x", TypeNum Int32), ("y", TypeNum Int32)]
                                 emptySymbolTable
-          let pointDecl = IRVarDecl "p"
+          let pointDecl = IRVarDecl (IRVarDeclData "p"
                 (IRTypeStruct "Point" (StructId 0))
                 (IRCall "struct_lit"
                   [IRLit (IRStringLit "Point"),
                    IRLit (IRInt32Lit 10),
-                   IRLit (IRInt32Lit 20)])
+                   IRLit (IRInt32Lit 20)]))
           let testMetaWithStruct = testMeta { metaSymTable = Just symTable }
           let program = IRProgram
                 [(IRFuncDecl "main" [] IRTypeVoid

--- a/test/Zap/IRSpec.hs
+++ b/test/Zap/IRSpec.hs
@@ -472,7 +472,7 @@ spec = do
                 [(mainFn, _)] -> do
                   let IRBlock _ stmts = fnBody mainFn
                   case head stmts of
-                    (IRVarDecl "x" _ (IRLit lit), meta) -> do
+                    (IRVarDecl (IRVarDeclData "x" _ (IRLit lit)), meta) -> do
                       metaLiteralType meta `shouldBe` Just (LitInt Int32)
                     _ -> expectationFailure "Expected variable declaration"
             Left err -> expectationFailure $ "IR conversion failed: " ++ show err
@@ -483,7 +483,7 @@ spec = do
           case convertToIR' ast st of
             Right (IRProgram [(mainFn, _)]) -> do
               case fnBody mainFn of
-                IRBlock _ ((IRVarDecl _ _ _, meta):_) ->
+                IRBlock _ ((IRVarDecl (IRVarDeclData _ _ _), meta):_) ->
                   metaLiteralType meta `shouldBe` Just (LitFloat Float32)
                 _ -> expectationFailure "Expected variable declaration"
             Left err -> expectationFailure $ show err
@@ -494,7 +494,7 @@ spec = do
           case convertToIR' ast st of
             Right (IRProgram [(mainFn, _)]) -> do
               case fnBody mainFn of
-                IRBlock _ ((IRVarDecl _ _ _, meta):_) ->
+                IRBlock _ ((IRVarDecl (IRVarDeclData _ _ _), meta):_) ->
                   metaLiteralType meta `shouldBe` Just LitString
                 _ -> expectationFailure "Expected variable declaration"
 
@@ -521,7 +521,7 @@ spec = do
                       [(declStmt, declMeta), (printStmt, printMeta), _] -> do
                           -- Check variable declaration
                           case declStmt of
-                              IRVarDecl name irType expr -> do
+                              IRVarDecl (IRVarDeclData name irType expr) -> do
                                   name `shouldBe` "x"
                                   irType `shouldBe` IRTypeInt32
                                   expr `shouldBe` IRLit (IRInt32Lit 5)
@@ -546,7 +546,7 @@ spec = do
           Right (IRProgram [(mainFn, _)]) -> do
             let IRBlock _ stmts = fnBody mainFn
             case head stmts of
-              (IRVarDecl "x" (IRTypeStruct "Box_i32" _) _, _) -> return ()
+              (IRVarDecl (IRVarDeclData "x" (IRTypeStruct "Box_i32" _) _), _) -> return ()
               other -> expectationFailure $ "Expected concrete Box instantiation, got: " ++ show other
           Left err -> expectationFailure $ show err
 
@@ -560,7 +560,7 @@ spec = do
           Right (IRProgram [(mainFn, _)]) -> do
             let IRBlock _ stmts = fnBody mainFn
             case stmts of
-              [ (IRVarDecl "x" (IRTypeStruct "Box_i32" _) declInit, declMeta),
+              [ (IRVarDecl (IRVarDeclData "x" (IRTypeStruct "Box_i32" _) declInit), declMeta),
                 (IRProcCall "print" [IRCall "field_access" [IRVar "x", IRLit (IRStringLit "value")]], printMeta),
                 (IRReturn Nothing, _) ] -> do
                   case declInit of

--- a/zap.cabal
+++ b/zap.cabal
@@ -40,7 +40,7 @@ library
       Paths_zap
   hs-source-dirs:
       src
-  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -fno-warn-name-shadowing -fno-warn-incomplete-uni-patterns -fno-warn-type-defaults -fno-warn-overlapping-patterns -fno-warn-x-partial
+  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -fno-warn-name-shadowing -fno-warn-incomplete-uni-patterns -fno-warn-type-defaults
   build-depends:
       array >=0.5 && <1
     , base >=4.7 && <5
@@ -67,7 +67,7 @@ executable zap-exe
       Paths_zap
   hs-source-dirs:
       app
-  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -fno-warn-name-shadowing -fno-warn-incomplete-uni-patterns -fno-warn-type-defaults -fno-warn-overlapping-patterns -fno-warn-x-partial -threaded -rtsopts -with-rtsopts=-N
+  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -fno-warn-name-shadowing -fno-warn-incomplete-uni-patterns -fno-warn-type-defaults -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       array >=0.5 && <1
     , base >=4.7 && <5
@@ -105,7 +105,7 @@ test-suite zap-test
       Paths_zap
   hs-source-dirs:
       test
-  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -fno-warn-name-shadowing -fno-warn-incomplete-uni-patterns -fno-warn-type-defaults -fno-warn-overlapping-patterns -fno-warn-x-partial -threaded -rtsopts -with-rtsopts=-N
+  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -fno-warn-name-shadowing -fno-warn-incomplete-uni-patterns -fno-warn-type-defaults -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       array >=0.5 && <1
     , base >=4.7 && <5

--- a/zap.cabal
+++ b/zap.cabal
@@ -40,7 +40,7 @@ library
       Paths_zap
   hs-source-dirs:
       src
-  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -fno-warn-name-shadowing -fno-warn-incomplete-uni-patterns -fno-warn-type-defaults
+  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -fno-warn-name-shadowing -fno-warn-incomplete-uni-patterns
   build-depends:
       array >=0.5 && <1
     , base >=4.7 && <5
@@ -67,7 +67,7 @@ executable zap-exe
       Paths_zap
   hs-source-dirs:
       app
-  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -fno-warn-name-shadowing -fno-warn-incomplete-uni-patterns -fno-warn-type-defaults -threaded -rtsopts -with-rtsopts=-N
+  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -fno-warn-name-shadowing -fno-warn-incomplete-uni-patterns -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       array >=0.5 && <1
     , base >=4.7 && <5
@@ -105,7 +105,7 @@ test-suite zap-test
       Paths_zap
   hs-source-dirs:
       test
-  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -fno-warn-name-shadowing -fno-warn-incomplete-uni-patterns -fno-warn-type-defaults -threaded -rtsopts -with-rtsopts=-N
+  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -fno-warn-name-shadowing -fno-warn-incomplete-uni-patterns -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       array >=0.5 && <1
     , base >=4.7 && <5

--- a/zap.cabal
+++ b/zap.cabal
@@ -40,7 +40,7 @@ library
       Paths_zap
   hs-source-dirs:
       src
-  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints
+  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -fno-warn-name-shadowing
   build-depends:
       array >=0.5 && <1
     , base >=4.7 && <5
@@ -67,7 +67,7 @@ executable zap-exe
       Paths_zap
   hs-source-dirs:
       app
-  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -threaded -rtsopts -with-rtsopts=-N
+  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -fno-warn-name-shadowing -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       array >=0.5 && <1
     , base >=4.7 && <5
@@ -105,7 +105,7 @@ test-suite zap-test
       Paths_zap
   hs-source-dirs:
       test
-  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -threaded -rtsopts -with-rtsopts=-N
+  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -fno-warn-name-shadowing -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       array >=0.5 && <1
     , base >=4.7 && <5

--- a/zap.cabal
+++ b/zap.cabal
@@ -40,7 +40,7 @@ library
       Paths_zap
   hs-source-dirs:
       src
-  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -fno-warn-name-shadowing
+  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -fno-warn-name-shadowing -fno-warn-incomplete-uni-patterns -fno-warn-type-defaults -fno-warn-overlapping-patterns -fno-warn-x-partial
   build-depends:
       array >=0.5 && <1
     , base >=4.7 && <5
@@ -67,7 +67,7 @@ executable zap-exe
       Paths_zap
   hs-source-dirs:
       app
-  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -fno-warn-name-shadowing -threaded -rtsopts -with-rtsopts=-N
+  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -fno-warn-name-shadowing -fno-warn-incomplete-uni-patterns -fno-warn-type-defaults -fno-warn-overlapping-patterns -fno-warn-x-partial -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       array >=0.5 && <1
     , base >=4.7 && <5
@@ -105,7 +105,7 @@ test-suite zap-test
       Paths_zap
   hs-source-dirs:
       test
-  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -fno-warn-name-shadowing -threaded -rtsopts -with-rtsopts=-N
+  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -fno-warn-name-shadowing -fno-warn-incomplete-uni-patterns -fno-warn-type-defaults -fno-warn-overlapping-patterns -fno-warn-x-partial -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       array >=0.5 && <1
     , base >=4.7 && <5


### PR DESCRIPTION
This PR resolves the CI pipeline failures caused by various GHC compiler warnings. The following changes have been made to ensure a clean build:

-     Disabled Shadowing Warnings: Added the -fno-warn-name-shadowing flag in package.yaml to suppress warnings related to variable shadowing.
-     Handled Unused Variables: Replaced unused variable names with _ to explicitly ignore them and avoid warnings.
-     Removed Redundant Imports: Cleaned up the codebase by removing unused and redundant library imports.
-     Exported Unused Functions: Exported previously unused functions from their respective modules to prevent unused warnings while maintaining accessibility.

Please review the changes and let me know if further modifications are needed.
Thank you! 🙌 @zacharycarter 